### PR TITLE
Default Webview constructor should set its own Chrome/WebView clients

### DIFF
--- a/src/android/XWalkCordovaWebView.java
+++ b/src/android/XWalkCordovaWebView.java
@@ -159,6 +159,8 @@ public class XWalkCordovaWebView implements CordovaWebView {
         {
             Log.d(TAG, "Your activity must implement CordovaInterface to work");
         }
+        this.setWebChromeClient(new XWalkCordovaChromeClient(this.cordova, this));
+        this.initWebViewClient(this.cordova);
         this.loadConfiguration();
         this.setup();
     }


### PR DESCRIPTION
The reflection code in infil00p/cordova-android@35ec24c always calls the default constructor, so the default constructor for XWalkCordovaWebView should be responsible for setting up its ChromeClient / WebViewClient objects, like the other constructors do.

(This gets the bridge callbacks working for me, and eliminates ~200 mobile spec failures)
