### PR TITLE
Updates for newest Crosswalk integration API (6.35.124+)

### DIFF
--- a/src/android/XWalkCordovaChromeClient.java
+++ b/src/android/XWalkCordovaChromeClient.java
@@ -47,7 +47,7 @@ import android.widget.RelativeLayout;
 
 import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.XWalkUIClientImpl;
+import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 
 /**
@@ -61,7 +61,7 @@ import org.xwalk.core.XWalkView;
  * @see XWalkCordovaWebViewClient
  * @see XWalkCordovaWebView
  */
-public class XWalkCordovaChromeClient extends XWalkUIClientImpl implements CordovaChromeClient {
+public class XWalkCordovaChromeClient extends XWalkUIClient implements CordovaChromeClient {
 
     public static final int FILECHOOSER_RESULTCODE = 5173;
     private static final String LOG_TAG = "CordovaChromeClient";
@@ -82,7 +82,7 @@ public class XWalkCordovaChromeClient extends XWalkUIClientImpl implements Cordo
      * @param cordova
      */
     public XWalkCordovaChromeClient(CordovaInterface cordova) {
-        super(cordova.getActivity(), null);
+        super(null);
         this.cordova = cordova;
     }
 
@@ -93,7 +93,7 @@ public class XWalkCordovaChromeClient extends XWalkUIClientImpl implements Cordo
      * @param app
      */
     public XWalkCordovaChromeClient(CordovaInterface ctx, XWalkCordovaWebView app) {
-        super(ctx.getActivity(), app.getView());
+        super(app.getView());
         this.cordova = ctx;
         this.appView = app;
         this.appView.getView().setXWalkWebChromeClient(new CordovaWebChromeClient(ctx.getActivity(), app));
@@ -324,7 +324,7 @@ public class XWalkCordovaChromeClient extends XWalkUIClientImpl implements Cordo
     private CordovaWebView appView;
 
     CordovaWebChromeClient(Context context, CordovaWebView view) {
-        super(context, (XWalkView) view);
+        super((XWalkView) view);
         appView = view;
     }
     

--- a/src/android/XWalkCordovaWebViewClient.java
+++ b/src/android/XWalkCordovaWebViewClient.java
@@ -46,7 +46,7 @@ import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
 import org.chromium.net.NetError;
-import org.xwalk.core.XWalkResourceClientImpl;
+import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkHttpAuthHandler;
@@ -63,7 +63,7 @@ import org.xwalk.core.XWalkHttpAuthHandler;
  * @see XwalkCordovaChromeClient
  * @see XWalkCordovaWebView
  */
-public class XWalkCordovaWebViewClient extends XWalkResourceClientImpl implements CordovaWebViewClient {
+public class XWalkCordovaWebViewClient extends XWalkResourceClient implements CordovaWebViewClient {
 
 	private static final String TAG = "CordovaWebViewClient";
 	private static final String CORDOVA_EXEC_URL_PREFIX = "http://cdv_exec/";
@@ -113,7 +113,7 @@ public class XWalkCordovaWebViewClient extends XWalkResourceClientImpl implement
      * @param cordova
      */
     public XWalkCordovaWebViewClient(CordovaInterface cordova) {
-    	super(cordova.getActivity(), null);
+    	super(null);
         this.cordova = cordova;
     }
 
@@ -124,7 +124,7 @@ public class XWalkCordovaWebViewClient extends XWalkResourceClientImpl implement
      * @param view
      */
     public XWalkCordovaWebViewClient(CordovaInterface cordova, XWalkCordovaWebView view) {
-    	super(cordova.getActivity(), view.getView());
+    	super(view.getView());
         this.cordova = cordova;
         this.appView = view;
         this.appView.getView().setXWalkClient(new CordovaInternalViewClient(view, cordova));
@@ -300,7 +300,7 @@ public class XWalkCordovaWebViewClient extends XWalkResourceClientImpl implement
    private boolean doClearHistory = false;
 
    CordovaInternalViewClient(CordovaWebView view, CordovaInterface ci) {
-       super(((XWalkView)view).getActivity(), (XWalkView) view);
+       super((XWalkView) view);
        cordova = ci;
        appView = view;
    }


### PR DESCRIPTION
The lastest Crosswalk code (as of crosswalk-project/crosswalk@1939881) has removed the `XWalkResourceClientImpl` and `XWalkUIClientImpl` classes. This patch gets cordova-crosswalk-engine working with the newest release. (It breaks compatibility with Crosswalk 6.35.123 and earlier, though)
