### PR TITLE
Update plugin.xml - additional uses-permission tags

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,5 +29,10 @@
         <source-file src="src/android/XWalkCordovaCookieManager.java" target-dir="src/org/crosswalk/engine" />
 
         <framework src="libs/xwalk_core_library/xwalk.gradle" custom="true" type="gradleReference" />
+        
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+            <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        </config-file>
     </platform>
 </plugin>


### PR DESCRIPTION
My app wouldn't run until I added these to the AndroidManifest.xml file. 

Adding this config-file target will address the issue. Lines 
    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
will be added to the AndroidManifest.xml automatically.

Thanks for the excellent plugin - I was shy about trying crosswalk, but this made it easy.
~Ed