### PR TITLE
setAcceptFileSchemeCookies Support cookies on file:// option

### DIFF
--- a/platforms/android/src/org/crosswalk/engine/XWalkCordovaCookieManager.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkCordovaCookieManager.java
@@ -29,6 +29,10 @@ class XWalkCordovaCookieManager implements ICordovaCookieManager {
         cookieManager = new XWalkCookieManager();
     }
 
+    public void setAcceptFileSchemeCookies(boolean accept) {
+        cookieManager.setAcceptFileSchemeCookies(accept);
+    }
+
     public void setCookiesEnabled(boolean accept) {
         cookieManager.setAcceptCookie(accept);
     }

--- a/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
+++ b/platforms/android/src/org/crosswalk/engine/XWalkWebViewEngine.java
@@ -27,7 +27,6 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.util.Log;
 import android.view.View;
-import android.webkit.ValueCallback;
 
 import java.io.File;
 import java.io.IOException;
@@ -310,16 +309,6 @@ public class XWalkWebViewEngine implements CordovaWebViewEngine {
             return;
         }
         webView.load(url, null);
-    }
-
-    /**
-     * This API is used in Cordova-Android 6.0.0 override from
-     *
-     * CordovaWebViewEngine.java
-     * @since Cordova 6.0
-     */
-    public void evaluateJavascript(String js, ValueCallback<String> callback) {
-        webView.evaluateJavascript(js, callback);
     }
 
     public boolean isXWalkReady() {

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,7 @@
         <preference name="XWALK_COMMANDLINE" default="--disable-pull-to-refresh-effect"/>
         <preference name="XWALK_MODE" default="embedded" />
         <preference name="XWALK_MULTIPLEAPK" default="true" />
+        <preference name="XWALK_FILE_SCHEME_COOKIES" default="false" />
         <config-file target="res/xml/config.xml" parent="/*">
             <preference name="webView" value="org.crosswalk.engine.XWalkWebViewEngine"/>
             <preference name="xwalkVersion" value="$XWALK_VERSION"/>
@@ -31,6 +32,7 @@
             <preference name="xwalkCommandLine" value="$XWALK_COMMANDLINE"/>
             <preference name="xwalkMode" value="$XWALK_MODE" />
             <preference name="xwalkMultipleApk" value="$XWALK_MULTIPLEAPK" />
+            <preference name="xwalkFileSchemeCookies" default="$XWALK_FILE_SCHEME_COOKIES" />
             <preference name="android-minSdkVersion" value="16" />
         </config-file>
 


### PR DESCRIPTION
Cookies are disabled in Chromium on file:// then in Ionic application, we have to use localStorage.
However, some third-party require cookies.

Settings <preference name="XWALK_FILE_SCHEME_COOKIES" value="true" /> in config.xml enable cookies